### PR TITLE
Tweaked parameters in minimal_example.py

### DIFF
--- a/python/minimal_example.py
+++ b/python/minimal_example.py
@@ -49,7 +49,7 @@ def minimal_example(width=2e-2, Nadapt=10, eta = 0.01):
      bc = DirichletBC(V, Expression(testsol), boundary)
      solve(a == L, u, bc)
      startTime = time()
-     H = metric_pnorm(u, eta, max_edge_length=1., max_edge_ratio=50)
+     H = metric_pnorm(u, eta, max_edge_length=3., max_edge_ratio=None)
      H = logproject(H)
      if iii != Nadapt-1:
       mesh = adapt(H)


### PR DESCRIPTION
2D pragmatic often fails with
Was something changed in smoothing? It seems pragmatic seems significantly less stable now. For 2D I often get
python: /home/kjensen/ese-home/projects/grg2/pragmatic/include/Smooth.h:765: bool Smooth<real_t, dim>::optimisation_linf_2d_kernel(index_t) [with real_t = double; int dim = 2; index_t = int]: Assertion `worst_element.second!=-1' failed.