### PR TITLE
Tweaked parameters of minimal_example3D.py

### DIFF
--- a/python/minimal_example3D.py
+++ b/python/minimal_example3D.py
@@ -48,7 +48,7 @@ def minimal_example3D(width=2e-2, Nadapt=10, eta = 0.04):
      solve(a == L, u, bc)
      fid << u
      startTime = time()
-     H = metric_pnorm(u, eta, max_edge_length=2., max_edge_ratio=50, CG1out=True)
+     H = metric_pnorm(u, eta, max_edge_length=2., max_edge_ratio=None, CG1out=True)
      #H = logproject(H)
      if iii != Nadapt-1:
       mesh = adapt(H) 


### PR DESCRIPTION
3D demos often fails with
python: /home/kjensen/ese-home/projects/grg2/pragmatic/include/Smooth.h:1382: bool Smooth<real_t, dim>::generate_location_3d(index_t, const real_t*, double*) const [with real_t = double; int dim = 3; index_t = int]: Assertion `tol>-10*double(2.22044604925031308085e-16L)' failed.