### PR TITLE
Fix example failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,3 +85,4 @@ TARGET_LINK_LIBRARIES(coarsen_mesh_3d ${PRAGMATIC_LIBRARIES})
 ADD_EXECUTABLE(jpeg2mesh ./tools/jpeg2mesh ./src/mpi_tools.cpp ./src/ticker.cpp)
 TARGET_LINK_LIBRARIES(jpeg2mesh ${PRAGMATIC_LIBRARIES})
 
+file(COPY ${CMAKE_SOURCE_DIR}/python DESTINATION ${CMAKE_BINARY_DIR}/)

--- a/python/adaptivity.py
+++ b/python/adaptivity.py
@@ -79,7 +79,7 @@ class ParameterException(Exception):
   pass
 
 try:
-  _libpragmatic = ctypes.cdll.LoadLibrary("../libpragmatic.so")
+  _libpragmatic = ctypes.cdll.LoadLibrary("../lib/libpragmatic.so")
 except:
   raise LibraryException("Failed to load libpragmatic.so")
 


### PR DESCRIPTION
Updating relative location of libpragmatic.so in the examples in `python/` and adding the subdir `python/` to out of source build directory.