### PR TITLE
Various fixes to pragmatic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if(MPI_FOUND)
   add_definitions(-DHAVE_MPI)
   include_directories(${MPI_CXX_INCLUDE_PATH} ${MPI_C_INCLUDE_PATH})
 
-  set (CMAKE_CXX_FLAGS ${MPI_CXX_COMPILE_FLAGS} ${CMAKE_CXX_FLAGS})
+  set (CMAKE_CXX_FLAGS "${MPI_CXX_COMPILE_FLAGS} ${CMAKE_CXX_FLAGS}")
   set (CMAKE_C_FLAGS ${MPI_C_COMPILE_FLAGS} ${CMAKE_C_FLAGS})
   set (CMAKE_LINK_FLAGS ${MPI_C_LINK_FLAGS} ${CMAKE_LINK_FLAGS})
   set (PRAGMATIC_LIBRARIES ${MPI_CXX_LIBRARIES} ${MPI_C_LIBRARIES} ${PRAGMATIC_LIBRARIES})
@@ -86,8 +86,15 @@ target_link_libraries(pragmatic ${PRAGMATIC_LIBRARIES})
 
 add_subdirectory(tests EXCLUDE_FROM_ALL)
 
+set(INSTALL_LIB_DIR "lib" CACHE PATH
+    "Installation directory for libraries")
+set(INSTALL_BIN_DIR "bin" CACHE PATH
+    "Installation directory for executables")
+set(INSTALL_INCLUDE_DIR "include/pragmatic" CACHE PATH
+    "Installation directory for header files")
+
 install(DIRECTORY include/ DESTINATION include/pragmatic FILES_MATCHING PATTERN *.h)
-install(FILES libpragmatic.so DESTINATION lib)
+install(TARGETS pragmatic DESTINATION "${INSTALL_LIB_DIR}")
 
 ADD_EXECUTABLE(coarsen_mesh_3d ./tools/coarsen_mesh_3d.cpp ./src/generate_Steiner_ellipse_3d.cpp  ./src/mpi_tools.cpp ./src/ticker.cpp)
 TARGET_LINK_LIBRARIES(coarsen_mesh_3d ${PRAGMATIC_LIBRARIES})
@@ -95,4 +102,3 @@ TARGET_LINK_LIBRARIES(coarsen_mesh_3d ${PRAGMATIC_LIBRARIES})
 ADD_EXECUTABLE(jpeg2mesh ./tools/jpeg2mesh ./src/mpi_tools.cpp ./src/ticker.cpp)
 TARGET_LINK_LIBRARIES(jpeg2mesh ${PRAGMATIC_LIBRARIES})
 
-file(COPY ${CMAKE_SOURCE_DIR}/python DESTINATION ${CMAKE_BINARY_DIR}/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,13 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 enable_language(CXX)
 enable_language(C)
 
+set(INSTALL_LIB_DIR "lib" CACHE PATH
+    "Installation directory for libraries")
+set(INSTALL_BIN_DIR "bin" CACHE PATH
+    "Installation directory for executables")
+set(INSTALL_INCLUDE_DIR "include/pragmatic" CACHE PATH
+    "Installation directory for header files")
+
 set (PRAGMATIC_LIBRARIES)
 # Use env variable iff it exists and command line arg was not given:
 if (NOT (DEFINED ENABLE_VTK) AND (NOT (x$ENV{ENABLE_VTK} STREQUAL x)))
@@ -66,6 +73,15 @@ if (OPENMP_FOUND)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
 
+find_package(PythonInterp 2.7)
+if(PYTHONINTERP_FOUND)
+    set(ADAPTIVITY_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/python/adaptivity.py.in")
+    set(ADAPTIVITY_PY "${CMAKE_CURRENT_SOURCE_DIR}/python/adaptivity.py")
+
+    # Generate adaptivity.py
+    configure_file(${ADAPTIVITY_PY_IN} ${ADAPTIVITY_PY})
+endif()
+
 FIND_PACKAGE(Metis REQUIRED)
 if(METIS_FOUND)
   include_directories(${METIS_INCLUDE_DIR})
@@ -85,13 +101,6 @@ add_library(pragmatic SHARED ${C_SOURCES} ${CXX_SOURCES})
 target_link_libraries(pragmatic ${PRAGMATIC_LIBRARIES})
 
 add_subdirectory(tests EXCLUDE_FROM_ALL)
-
-set(INSTALL_LIB_DIR "lib" CACHE PATH
-    "Installation directory for libraries")
-set(INSTALL_BIN_DIR "bin" CACHE PATH
-    "Installation directory for executables")
-set(INSTALL_INCLUDE_DIR "include/pragmatic" CACHE PATH
-    "Installation directory for header files")
 
 install(DIRECTORY include/ DESTINATION include/pragmatic FILES_MATCHING PATTERN *.h)
 install(TARGETS pragmatic DESTINATION "${INSTALL_LIB_DIR}")

--- a/include/cpragmatic.h
+++ b/include/cpragmatic.h
@@ -1,32 +1,21 @@
 #ifndef CPRAGMATIC_H
 #define CPRAGMATIC_H
 
-#include <cassert>
-
-// The order of these matters (!)
-#include "Surface.h"
-#include "Coarsen.h"
-
-#include "Mesh.h"
-#include "MetricField.h"
-#include "Refine.h"
-#include "Swapping.h"
-#include "Smooth.h"
-
-extern Mesh<double, int>* _cpragmatic_mesh;
-extern Surface<double, int>* _cpragmatic_surface;
-extern MetricField<double, int>* _cpragmatic_metric_field;
-
+#if defined(__cplusplus)
 extern "C" {
-  void cpragmatic_initialise_2d(int* NNodes, int* NElements, int* enlist, double* x, double* y);
-  void cpragmatic_set_boundary(int* nfacets, int* facets, int* boundary_ids);
-  void cpragmatic_set_metric(double* metric);
-  void cpragmatic_metric_add_field(double* psi, double* error, int* pnorm);
-  void cpragmatic_apply_metric_bounds(double* min_len, double* max_len);
-  void cpragmatic_adapt(int* smooth);
-  void cpragmatic_query_output(int* NNodes, int* NElements);
-  void cpragmatic_get_output_2d(int* enlist, double* x, double* y);
-  void cpragmatic_finalise(void);
+#endif
+  void pragmatic_2d_init(const int *NNodes, const int *NElements, const int *enlist, const double *x, const double *y);
+  void pragmatic_3d_init(const int *NNodes, const int *NElements, const int *enlist, const double *x, const double *y, const double *z);
+  void pragmatic_set_boundary(const int *nfacets, const int *facets, const int *ids);
+  void pragmatic_set_metric(const double *metric);
+  void pragmatic_add_field(const double *psi, const double *error, int *pnorm);
+  void pragmatic_adapt(void);
+  void pragmatic_get_info(int *NNodes, int *NElements);
+  void pragmatic_get_coords_2d(double *x, double *y);
+  void pragmatic_get_coords_3d(double *x, double *y, double *z);
+  void pragmatic_get_elements(int *elements);
+  void pragmatic_finalize(void);
+#if defined(__cplusplus)
 }
-  
+#endif
 #endif

--- a/python/adaptivity.py.in
+++ b/python/adaptivity.py.in
@@ -79,9 +79,10 @@ class ParameterException(Exception):
   pass
 
 try:
-  _libpragmatic = ctypes.cdll.LoadLibrary("../lib/libpragmatic.so")
+  path = "${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}/libpragmatic${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  _libpragmatic = ctypes.cdll.LoadLibrary(path)
 except:
-  raise LibraryException("Failed to load libpragmatic.so")
+  raise LibraryException("Failed to load libpragmatic in %s" % path)
 
 def refine_metric(M, factor):
   class RefineExpression(Expression):


### PR DESCRIPTION
This branch offers:
 - a working cpragmatic.h
 - various fixes to the CMakeLists.txt (e.g. it assumed the library suffix was .so, not true on OSX)
 - it has CMake generate the adaptivity.py from an adaptivity.py.in, so that it has the right path to the library