### PR TITLE
Travis fix timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ script:
   - make
   - cd tests/
   - make
-  - travis_wait make test
+  - make test
 

--- a/tests/unittest
+++ b/tests/unittest
@@ -65,6 +65,27 @@ class UnitTest:
 
         return (passcount, warncount, failcount)
 
+class UnitTestTimer:
+    def __init__(self, min):
+        from multiprocessing import Process
+        self.minutes = min
+        self.waitsec = 60
+        self.cp = Process(target=self.run)
+
+    def run(self):
+        import time
+        for i in range(self.minutes):
+            out = "Running for %i minute" %(i)
+            if (i != 1): out = out+"s"
+            print out
+            time.sleep(self.waitsec)
+
+    def start(self):
+        self.cp.start()
+
+    def terminate(self):
+        self.cp.terminate()
+
 class UnitTestHarness:
     def __init__(self, dir):
         self.tests = []
@@ -84,9 +105,13 @@ class UnitTestHarness:
         warntests = []
         failtests = []
 
+        UTTimer = UnitTestTimer(30)
+        UTTimer.start()
+
         for test in self.tests:
+
             exitStatus = test.run()
-            
+
             (P, W, F) = test.parse()
 
             if (W, F) == (0, 0) and P > 0:
@@ -105,7 +130,7 @@ class UnitTestHarness:
 
             if F > 0:
               failtests.append(test.exe)
-              
+
             if not exitStatus == 0:
               print "    Failure: non-zero exit code from test"
               failcount += 1
@@ -115,6 +140,8 @@ class UnitTestHarness:
             passcount += P
             warncount += W
             failcount += F
+
+        UTTimer.terminate()
 
         print "  RESULTS"
         print "    Passes:   %d" % passcount

--- a/tests/unittest
+++ b/tests/unittest
@@ -69,16 +69,14 @@ class UnitTestTimer:
     def __init__(self, min):
         from multiprocessing import Process
         self.minutes = min
-        self.waitsec = 60
+        self.waitsec = 7*60
         self.cp = Process(target=self.run)
 
     def run(self):
         import time
         for i in range(self.minutes):
-            out = "Running for %i minute" %(i)
-            if (i != 1): out = out+"s"
-            print out
             time.sleep(self.waitsec)
+            print "Still running..."
 
     def start(self):
         self.cp.start()
@@ -105,10 +103,10 @@ class UnitTestHarness:
         warntests = []
         failtests = []
 
-        UTTimer = UnitTestTimer(30)
-        UTTimer.start()
-
         for test in self.tests:
+
+            UTTimer = UnitTestTimer(60)
+            UTTimer.start()
 
             exitStatus = test.run()
 
@@ -141,7 +139,7 @@ class UnitTestHarness:
             warncount += W
             failcount += F
 
-        UTTimer.terminate()
+            UTTimer.terminate()
 
         print "  RESULTS"
         print "    Passes:   %d" % passcount


### PR DESCRIPTION
Despite all the previous bufixes, with `ENABLE_OPENMP=FALSE` the entire procedure `make test` could run for more than 20 minutes. Removing the wrapper `travis_wait` defaults back to the 10 minute limit without an output to `stdout`. Since the test `test_adapt_3d`sometimes took more than 10 minutes in this configuration, testharness now spawns another process and generates some output that lets Travis know the process is still running.
This branch fixes #40. 