### PR TITLE
Added fail over to ../lib/libpragmatic in pragmatic.py.in

### DIFF
--- a/python/adaptivity.py.in
+++ b/python/adaptivity.py.in
@@ -82,7 +82,10 @@ try:
   path = "${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}/libpragmatic${CMAKE_SHARED_LIBRARY_SUFFIX}"
   _libpragmatic = ctypes.cdll.LoadLibrary(path)
 except:
-  raise LibraryException("Failed to load libpragmatic in %s" % path)
+  try:
+    _libpragmatic = ctypes.cdll.LoadLibrary('../lib/libpragmatic.so')
+  except:
+    raise LibraryException("Failed to load libpragmatic in %s" % path)
 
 def refine_metric(M, factor):
   class RefineExpression(Expression):


### PR DESCRIPTION
This fix allows the python demos to work with the current installation instructions