### PR TITLE
Adaptivity.py: Failsafe for loading libpragmatic.so

### DIFF
--- a/python/adaptivity.py.in
+++ b/python/adaptivity.py.in
@@ -82,7 +82,13 @@ try:
   path = "${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}/libpragmatic${CMAKE_SHARED_LIBRARY_SUFFIX}"
   _libpragmatic = ctypes.cdll.LoadLibrary(path)
 except:
-  raise LibraryException("Failed to load libpragmatic in %s" % path)
+  errmsg = "Failed to load libpragmatic in\n   %s" % (path)
+  try:
+    path = "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libpragmatic${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    _libpragmatic = ctypes.cdll.LoadLibrary(path)
+  except:
+    errmsg += " and\n   %s" % (path)
+    raise LibraryException(errmsg)
 
 def refine_metric(M, factor):
   class RefineExpression(Expression):


### PR DESCRIPTION
If libpragmatic could not be loaded from the install directory, try the build directory.
This is independent of building in or out of the source directory.
Thanks to @KristianE86.