### PR TITLE
Fix crash on test_adapt.py (from branch)

### DIFF
--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -2113,6 +2113,7 @@ private:
 
         _ENList.resize(NElements*nloc);
         quality.resize(NElements);
+        regions.resize(NElements);
         _coords.resize(NNodes*ndims);
         metric.resize(NNodes*msize);
         NNList.resize(NNodes);


### PR DESCRIPTION
It seems like the `Mesh.regions` variable is never initialized, which leads to the crashes in `test_adapt.py` described in #130  and #132 (which I think may be duplicates).  I'm not super familiar with the structure of the code, but it seems like adding an initial `resize()` to the initialization does the trick.  Now runs all three python test scripts.

Duplicate of #134, except compare branch isn't `master` on the fork (sorry about that).